### PR TITLE
Fix of _createStream method

### DIFF
--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -147,6 +147,6 @@ class GeoFireCollectionRef {
 
   /// create an observable for [ref], [ref] can be [Query] or [CollectionReference]
   Stream<QuerySnapshot> _createStream(var ref) {
-    return Stream<QuerySnapshot>.fromFuture(ref.snapshots());
+    return ref.snapshots();
   }
 }


### PR DESCRIPTION
I tested the package carefully, and found out the updated _createStream method throws this error:

**`Unhandled Exception: type '_BroadcastStream<QuerySnapshot>' is not a subtype of type 'Future<QuerySnapshot>`**

Based on the documentation, we do not need to cast it as a stream using Stream.fromFuture
Sorry for not testing it correctly the first time.