### PR TITLE
fix!: override == and hashCode for GeoFirePoint

### DIFF
--- a/lib/src/point.dart
+++ b/lib/src/point.dart
@@ -52,6 +52,17 @@ class GeoFirePoint {
     return GeoFirePoint.distanceBetween(
         from: coords, to: Coordinates(lat, lng));
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GeoFirePoint &&
+          runtimeType == other.runtimeType &&
+          latitude == other.latitude &&
+          longitude == other.longitude;
+
+  @override
+  int get hashCode => latitude.hashCode ^ longitude.hashCode;
 }
 
 class Coordinates {


### PR DESCRIPTION
== and hashCode are based on lat and lon values

BREAKING CHANGE: == and hashCode behaves differently in collection and == operations for GeoFirePoint
fixes #162 