### PR TITLE
Move flutter_lints to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
   cloud_firestore: ^3.1.6
   rxdart: ^0.27.3
-  flutter_lints: ^1.0.0
 
 dev_dependencies:
+  flutter_lints: ^1.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Due to the `flutter_lints` package being in the dependencies many people will get version conflicts.

`flutter_lints` is only used in development so doesn't need to be shipped with this package. This will solve conflicts for all versions going forward and can be updated internally at any stage to fit project needs.

Moving to `dev_dependencies:` is also recommended by the flutter team when using `flutter_lints` as seen [here](https://docs.flutter.dev/release/breaking-changes/flutter-lints-package#:~:text=Add%20a%20dev_dependency%20on%20package%3Aflutter_lints%20to%20your%20project%E2%80%99s%20pubspec.yaml%20by%20running%20flutter%20pub%20add%20%2D%2Ddev%20flutter_lints%20in%20the%20root%20directory%20of%20the%20project.).